### PR TITLE
libsign: fix qa issues

### DIFF
--- a/recipes-devtools/libsign/libsign_git.bb
+++ b/recipes-devtools/libsign/libsign_git.bb
@@ -40,12 +40,17 @@ EXTRA_OEMAKE = " \
     SIGNATURELET_DIR="${STAGING_LIBDIR_NATIVE}/signaturelet" \
 "
 
+do_compile_prepend() {
+    # fix host contamination issue
+    sed -i '/$(libdir)/d' ${S}/env.mk
+}
+
 do_install() {
     oe_runmake install DESTDIR="${D}"
 }
 
 FILES_${PN} = "\
-    ${sbindir} \
+    ${bindir} \
     ${libdir} \
 "
 


### PR DESCRIPTION
Fix libsign QA installed-vs-shipped and compile-host-path issues.

| WARNING: libsign-0.3.2+gitAUTOINC+d283d61a84-r0 do_package: QA Issue: libsign: Files/directories were installed but not shipped in any package:
|   /usr/bin/selsign
| ERROR: libsign-0.3.2+gitAUTOINC+d283d61a84-r0 do_package_qa: QA Issue: libsign: The compile log indicates that host include and/or library paths were used.

Signed-off-by: Kai Kang <kai.kang@windriver.com>