### PR TITLE
seloader: skip verifications if MOK Secure Boot disabled

### DIFF
--- a/recipes-bsp/seloader/seloader_git.bb
+++ b/recipes-bsp/seloader/seloader_git.bb
@@ -26,7 +26,7 @@ PR = "r0"
 SRC_URI = " \
     git://github.com/jiazhang0/SELoader.git \
 "
-SRCREV = "32e3292c33603f319354aac273938fe63897a8da"
+SRCREV = "e6c6cbe6405f01d58f9e9cbb0115a12ae49454a0"
 PV = "0.4.5+git${SRCPV}"
 
 COMPATIBLE_HOST = '(i.86|x86_64).*-linux'


### PR DESCRIPTION
Upgrade seloader to 7191b0f5 for allowing to skip the verifications
for grub, kernel images if MOK SecureBoot is disabled.

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>